### PR TITLE
Tweaks to preview images in Jupyter notebooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+v0.6.1 [Unreleased]
+-------------------
+
+Fixed
+^^^^^
+
+- Preview images are no longer displayed twice in jupyter notebooks
+- Preview images no longer display the x and y axis numbers.
+
 v0.6.0 - 2018-10-07
 -------------------
 

--- a/stylo/image/image.py
+++ b/stylo/image/image.py
@@ -28,9 +28,17 @@ class Image(ABC):
             plot_size = 12
 
         fig, ax = plt.subplots(1, figsize=(plot_size, plot_size))
+
+        # Hide the axis - show just the image
+        fig.axes[0].get_yaxis().set_visible(False)
+        fig.axes[0].get_xaxis().set_visible(False)
+
+        # Draw the image
         ax.imshow(image)
 
-        return fig
+        # Return just the axis, jupyter notebooks will capture the figure and
+        # display it anyway.
+        return ax
 
     def _save(self, image, filename):
 


### PR DESCRIPTION
- Fixed the issue where jupyter notebooks display two copies of the plot
- Disabled the axis so we now just see the image.