### PR TITLE
Base64 encoded images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 v0.6.1 [Unreleased]
 -------------------
 
+Added
+^^^^^
+
+- New :code:`preview` keyword argument to images, set this to :code:`False` if
+  you don't want a matplotlib figure returned.
+- New :code:`encode` keyword argument to images, setting this to :code:`True`
+  will return a base64 encoded string representation of the image in PNG format.
+
 Fixed
 ^^^^^
 

--- a/stylo/image/image.py
+++ b/stylo/image/image.py
@@ -1,7 +1,9 @@
-from abc import ABC, abstractmethod
-
+import base64
+import io
 import PIL as P
 import matplotlib.pyplot as plt
+
+from abc import ABC, abstractmethod
 
 
 class Drawable:
@@ -15,14 +17,31 @@ class Drawable:
 
 
 class Image(ABC):
-    def __call__(self, width, height, filename=None, plot_size=None):
+    def __call__(
+        self, width, height, filename=None, plot_size=None, encode=None, preview=True
+    ):
 
-        image = self._render(width, height)
-        self.data = image
+        self.data = self._render(width, height)
 
-        if filename is not None:
-            self._save(image, filename)
+        if filename:
+            self.save(filename)
             return
+
+        if encode:
+            return self.encode()
+
+        if preview:
+            return self.preview(plot_size)
+
+    def preview(self, plot_size):
+        """Generate a matplotlib plot of the image data which can then be viewed from
+        a Jupyter Notebook.
+
+        :param plot_size: This controls how large the generated plot is
+        :type plot_size: int
+
+        :returns: A matplotlib AxesImage object.
+        """
 
         if plot_size is None:
             plot_size = 12
@@ -34,22 +53,45 @@ class Image(ABC):
         fig.axes[0].get_xaxis().set_visible(False)
 
         # Draw the image
-        ax.imshow(image)
+        ax.imshow(self.data)
 
         # Return just the axis, jupyter notebooks will capture the figure and
         # display it anyway.
         return ax
 
-    def _save(self, image, filename):
+    def encode(self):
+        """Encode the image as a PNG represented by a base64 string.
 
-        height, width, _ = image.shape
+        :return: The image encoded as a base64 string.
+        """
 
-        pil_image = P.Image.frombuffer(
-            "RGB", (width, height), image, "raw", "RGB", 0, 1
-        )
+        image = self._to_pil_image()
+
+        with io.BytesIO() as byte_stream:
+            image.save(byte_stream, "PNG")
+            image_bytes = byte_stream.getvalue()
+
+        return base64.b64encode(image_bytes)
+
+    def save(self, filename):
+        """Save the image to file as a PNG image.
+
+        If the given filename already exists the existing image will be overwritten.
+
+        :param filename: The file to save the image to.
+        :type filename: str
+        """
+
+        image = self._to_pil_image()
 
         with open(filename, "wb") as f:
-            pil_image.save(f)
+            image.save(f)
+
+    def _to_pil_image(self):
+        """Convert the numpy representation of the image into a PIL.Image object."""
+
+        height, width, _ = self.data.shape
+        return P.Image.frombuffer("RGB", (width, height), self.data, "raw", "RGB", 0, 1)
 
     @property
     def data(self):

--- a/stylo/testing/image.py
+++ b/stylo/testing/image.py
@@ -1,0 +1,49 @@
+import base64
+from hypothesis import given
+
+from stylo.testing.strategies import dimension
+
+
+class BaseImageTest:
+    """A base class for writing :code:`Image` implementations.
+
+    When writing your test case for a new :code:`Image` implementation you need to
+    declare it as follows.
+
+    .. code-block:: python
+
+       from unittest import TestCase
+       from stylo.testing.image import BaseImageTest
+
+       class TestMyImage(TestCase, BaseImageTest):
+           ...
+
+    .. note::
+
+       The order in which you write the classes is *very* important.
+
+    You also need to define the :code:`setUp` method to set the :code:`image` attribute
+    equal to an instance of your image implementation.
+
+    .. code-block:: python
+
+       def setUp(self):
+           self.image = MyImage()
+
+    Then in addition to any tests you write, your :code:`Image` implementation will be
+    automatically tested to see if passes the checks defined below.
+    """
+
+    @given(width=dimension, height=dimension)
+    def test_encode(self, width, height):
+        """Ensure that if the :code:`encode=True` keyword argument is given then a
+        base64 encoded string representing the image in PNG format is returned."""
+
+        # Every PNG image starts with the same magic number.
+        # https://en.wikipedia.org/wiki/Portable_Network_Graphics
+        magic = base64.b64encode(bytes.fromhex("89504e470d0a1a0a"))
+
+        image_bytes = self.image(width, height, encode=True)
+
+        assert isinstance(image_bytes, (bytes,)), "Expected byte string"
+        assert magic[0:11] == image_bytes[0:11]

--- a/tests/image/test_layered.py
+++ b/tests/image/test_layered.py
@@ -1,0 +1,20 @@
+import pytest
+from unittest import TestCase
+
+from stylo.shape import Circle
+from stylo.color import FillColor
+from stylo.image import LayeredImage
+from stylo.testing.image import BaseImageTest
+
+
+@pytest.mark.image
+class TestLayeredImage(TestCase, BaseImageTest):
+    """Tests for the :code:`LayeredImage` object."""
+
+    def setUp(self):
+        circle, black = Circle(0, 0, 0.9), FillColor()
+
+        image = LayeredImage()
+        image.add_layer(circle, black)
+
+        self.image = image

--- a/tests/image/test_simple.py
+++ b/tests/image/test_simple.py
@@ -1,0 +1,15 @@
+import pytest
+from unittest import TestCase
+
+from stylo.shape import Circle
+from stylo.color import FillColor
+from stylo.image import SimpleImage
+from stylo.testing.image import BaseImageTest
+
+
+@pytest.mark.image
+class TestSimpleImage(TestCase, BaseImageTest):
+    """Tests for the :code:`SimpleImage` object."""
+
+    def setUp(self):
+        self.image = SimpleImage(Circle(0, 0, 0.9), FillColor())


### PR DESCRIPTION
- Images can now generate base64 encoded string representations of
  themselves
- Added a new `preview` keyword argument to control if a preview
  of the image should be generated.
- Added a new `encode` keyword argument to control if the base64
  representation should be generated.

- Also started work on an image test suite