### PR TITLE
Import commonly used objects into the top-level namespace

### DIFF
--- a/stylo/__init__.py
+++ b/stylo/__init__.py
@@ -1,1 +1,21 @@
+from .color import FillColor  # noqa: F401
+from .domain.transform import (  # noqa: F401
+    horizontal_shear,
+    rotate,
+    translate,
+    vertical_shear,
+)
+from .image import LayeredImage, SimpleImage  # noqa: F401
+from .math import anded, lerp  # noqa: F401
+from .shape import (  # noqa: F401
+    Circle,
+    Ellipse,
+    ImplicitXY,
+    Rectangle,
+    Shape,
+    Square,
+    Triangle,
+)
+from .time import Timeline  # noqa: F401
+
 from ._version import __version__  # noqa: F401

--- a/stylo/math/__init__.py
+++ b/stylo/math/__init__.py
@@ -1,1 +1,2 @@
+from .logic import anded  # noqa: F401
 from .interpolation import lerp  # noqa: F401

--- a/stylo/math/logic.py
+++ b/stylo/math/logic.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+
+class LogicalAnd:
+    """Represents a logical AND between N values.
+
+    Yes, there is currently no reason to use a class but where I want to
+    take this in the near future will require a class.
+    """
+
+    def __init__(self, values):
+        self.values = values
+
+    def __call__(self):
+
+        result = True
+
+        for v in self.values:
+            result = np.logical_and(result, v)
+
+        return result
+
+
+def anded(*args):
+    logical_and = LogicalAnd(args)
+    return logical_and()


### PR DESCRIPTION
This enables the `import stylo as xyz` interface - Closes (#76)