### PR TITLE
Renaming the Expression system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__/
 
 env/
 dist/
-docs/api
 docs/_build
 
 *.png

--- a/docs/_references.rst
+++ b/docs/_references.rst
@@ -2,8 +2,8 @@
 
 .. |Source| replace:: :class:`Source <stylo.Source>`
 
-.. |StyExpr| replace:: :class:`StyExpr <stylo.math.expr.StyExpr>`
-.. |StyExpr.eval| replace:: :meth:`eval <stylo.math.expr.StyExpr.eval>`
+.. |Expression| replace:: :class:`Expression <stylo.math.expr.Expression>`
+.. |Expression.eval| replace:: :meth:`eval <stylo.math.expr.Expression.eval>`
 
 .. |trace| replace:: :func:`trace <stylo.trace>`
 

--- a/docs/_references.rst
+++ b/docs/_references.rst
@@ -2,6 +2,9 @@
 
 .. |Source| replace:: :class:`Source <stylo.Source>`
 
+.. |StyExpr| replace:: :class:`StyExpr <stylo.math.expr.StyExpr>`
+.. |StyExpr.eval| replace:: :meth:`eval <stylo.math.expr.StyExpr.eval>`
+
 .. |trace| replace:: :func:`trace <stylo.trace>`
 
 .. |tweakable| replace:: :func:`tweakable <stylo.tweakable>`

--- a/docs/api/expressions.rst
+++ b/docs/api/expressions.rst
@@ -1,0 +1,66 @@
+.. _api_expressions:
+
+Expressions Reference
+---------------------
+
+.. autoclass:: stylo.math.expr.Expr
+
+.. autoclass:: stylo.Const
+
+.. autoclass:: stylo.Name
+
+.. autofunction:: stylo.abs
+
+.. autofunction:: stylo.anded
+
+.. autofunction:: stylo.cos
+
+.. autofunction:: stylo.neg
+
+.. autofunction:: stylo.orded
+
+.. autofunction:: stylo.sin
+
+.. autofunction:: stylo.sqrt
+
+.. autofunction:: stylo.math.expr.define_binary_op
+
+.. autofunction:: stylo.math.expr.define_function
+
+.. autoclass:: stylo.math.expr.Divide
+
+.. autoclass:: stylo.math.expr.FloorDivide
+
+.. autoclass:: stylo.math.expr.Minus
+
+.. autoclass:: stylo.math.expr.Modulo
+
+.. autoclass:: stylo.math.expr.Multiply
+
+.. autoclass:: stylo.math.expr.Plus
+
+.. autoclass:: stylo.math.expr.Power
+
+.. autoclass:: stylo.math.expr.And
+
+.. autoclass:: stylo.math.expr.Or
+
+.. autoclass:: stylo.math.expr.GreaterEqual
+
+.. autoclass:: stylo.math.expr.GreaterThan
+
+.. autoclass:: stylo.math.expr.LessEqual
+
+.. autoclass:: stylo.math.expr.LessThan
+
+.. autoclass:: stylo.math.expr.Abs
+
+.. autoclass:: stylo.math.expr.Cos
+
+.. autoclass:: stylo.math.expr.Neg
+
+.. autoclass:: stylo.math.expr.Sqrt
+
+.. autoclass:: stylo.math.expr.Sin
+
+

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,36 @@
+.. _api:
+
+API Reference
+=============
+
+Public API
+----------
+
+Here is stylo's public API, while it is too early for us to make any real
+stability guarantees we certainly try to keep from changing what is documented
+here too drastically.
+
+
+.. autoclass:: stylo.Source
+
+.. autoclass:: stylo.domain.Tweakable
+
+.. autofunction:: stylo.trace
+
+.. autofunction:: stylo.tweakable
+
+Internal API
+------------
+
+Items included here are considered "private" or internal, we make no effort to
+keep what is documented here stable and it can change without warning. This
+section is mainly for the benefit of contributors.
+
+
+Index
+-----
+
+.. toctree::
+   :maxdepth: 2
+
+   expressions

--- a/docs/extend/expressions.rst
+++ b/docs/extend/expressions.rst
@@ -45,4 +45,23 @@ function::
 Evaluating Expressions
 ----------------------
 
+There are a number of ways in which a
+
+Perhaps the most common task you will want to perform with an expression will
+be to evaluate it. In the case where all the values are already known this can
+be as simple as calling the |StyExpr.eval| method on the expression::
+
+    >>> one = st.StyConst(1)
+    >>> two = st.StyConst(2)
+
+    >>> plus = one + two
+    >>> plus
+    (+ 1 2)
+
+    >>> plus.eval()
+    3
+
+
+
+
 

--- a/docs/extend/expressions.rst
+++ b/docs/extend/expressions.rst
@@ -49,10 +49,10 @@ There are a number of ways in which a
 
 Perhaps the most common task you will want to perform with an expression will
 be to evaluate it. In the case where all the values are already known this can
-be as simple as calling the |StyExpr.eval| method on the expression::
+be as simple as calling the |Expr.eval| method on the expression::
 
-    >>> one = st.StyConst(1)
-    >>> two = st.StyConst(2)
+    >>> one = st.Const(1)
+    >>> two = st.Const(2)
 
     >>> plus = one + two
     >>> plus

--- a/docs/extend/index.rst
+++ b/docs/extend/index.rst
@@ -12,5 +12,6 @@ Index
 .. toctree::
    :maxdepth: 2
 
+   expressions
    sources
    tweakables

--- a/stylo/__init__.py
+++ b/stylo/__init__.py
@@ -1,10 +1,12 @@
-from .color import FillColor  # noqa: F401
-from .domain import Source, Tweakable, tweakable  # noqa: F401
-from .image import ImageFactory, StandardImage  # noqa: F401
-from .math import (  # noqa: F401
-    StyConst,
-    StyExpr,
-    StyName,
+# flake8: noqa
+from ._version import __version__
+from .color import FillColor
+from .domain import Source, Tweakable, tweakable
+from .image import ImageFactory, StandardImage
+from .math import (
+    Const,
+    Expression,
+    Name,
     abs,
     anded,
     cos,
@@ -15,15 +17,5 @@ from .math import (  # noqa: F401
     sqrt,
     trace,
 )
-from .shapes import (  # noqa: F401
-    Circle,
-    Ellipse,
-    ImplicitXY,
-    Rectangle,
-    shape,
-    Square,
-    Triangle,
-)
-from .time import Timeline  # noqa: F401
-
-from ._version import __version__  # noqa: F401
+from .shapes import Circle, Ellipse, ImplicitXY, Rectangle, Square, Triangle, shape
+from .time import Timeline

--- a/stylo/math/__init__.py
+++ b/stylo/math/__init__.py
@@ -1,13 +1,4 @@
-from .expr import (  # noqa: F401
-    StyConst,
-    StyExpr,
-    StyName,
-    sin,
-    cos,
-    sqrt,
-    abs,
-    neg,
-    trace,
-)
-from .logic import anded, ored  # noqa: F401
-from .interpolation import lerp  # noqa: F401
+# flake8: noqa
+from .expr import Const, Expression, Name, abs, cos, neg, sin, sqrt, trace
+from .interpolation import lerp
+from .logic import anded, ored

--- a/stylo/shapes/base.py
+++ b/stylo/shapes/base.py
@@ -2,7 +2,7 @@ import random
 import string
 import inspect
 
-from stylo.math import StyName
+from stylo.math import Name
 
 
 NAMECHARS = string.ascii_letters + string.digits
@@ -101,7 +101,7 @@ def _shape_expr_property():
 
     def getter(self):
         args = {
-            _normalise_name(name): StyName(name)
+            _normalise_name(name): Name(name)
             for name in self.args + list(self._params.keys())
         }
         return self._func(**args)

--- a/stylo/testing/math.py
+++ b/stylo/testing/math.py
@@ -1,5 +1,5 @@
 import numpy as np
-from stylo.math.expr import StyConst
+from stylo.math.expr import Const
 
 
 def ensure_equivalent(f):
@@ -14,7 +14,7 @@ def ensure_equivalent(f):
     """
 
     def wrapped_func(**kwargs):
-        wrapped_kwargs = {k: StyConst(v) for k, v in kwargs.items()}
+        wrapped_kwargs = {k: Const(v) for k, v in kwargs.items()}
 
         for arg, warg in zip(kwargs.values(), wrapped_kwargs.values()):
             arg_check = arg == warg.eval()
@@ -72,10 +72,10 @@ class BaseBinaryOpTest:
 
     def test_examples_both_wrapped(self):
         """Ensure that the operation produces the correct output when both of the
-        inputs are a :code:`StyConst` instance."""
+        inputs are a :code:`Const` instance."""
 
         for a, b, res in self.examples:
-            op = self.operation(StyConst(a), StyConst(b))
+            op = self.operation(Const(a), Const(b))
 
             if isinstance(res, (np.ndarray,)):
                 assert (res == op.eval()).all()
@@ -85,10 +85,10 @@ class BaseBinaryOpTest:
 
     def test_examples_left_wrapped(self):
         """Ensure that the operation produces the correct output when only the
-        left input is a :code:`StyConst` instance."""
+        left input is a :code:`Const` instance."""
 
         for a, b, res in self.examples:
-            op = self.operation(StyConst(a), b)
+            op = self.operation(Const(a), b)
 
             if isinstance(res, (np.ndarray,)):
                 assert (res == op.eval()).all()
@@ -98,10 +98,10 @@ class BaseBinaryOpTest:
 
     def test_examples_right_wrapped(self):
         """Ensure that the operation produces the correct output when only the
-        right input is a :code:`StyConst` instance."""
+        right input is a :code:`Const` instance."""
 
         for a, b, res in self.examples:
-            op = self.operation(a, StyConst(b))
+            op = self.operation(a, Const(b))
 
             if isinstance(res, (np.ndarray,)):
                 assert (res == op.eval()).all()
@@ -111,7 +111,7 @@ class BaseBinaryOpTest:
 
     def test_examples_unwrapped(self):
         """Ensure that the operation produces the correct output when none of the
-        inputs are a :code:`StyConst` instance."""
+        inputs are a :code:`Const` instance."""
 
         for a, b, res in self.examples:
             op = self.operation(a, b)

--- a/tests/math/test_expr.py
+++ b/tests/math/test_expr.py
@@ -8,29 +8,29 @@ import numpy as np
 
 from unittest import TestCase
 from stylo.math.expr import (
-    StyAnd,
-    StyDivide,
-    StyFloorDivide,
-    StyGreaterEqual,
-    StyGreaterThan,
-    StyLessEqual,
-    StyLessThan,
-    StyMinus,
-    StyModulo,
-    StyMultiply,
-    StyOr,
-    StyPlus,
-    StyPower,
+    And,
+    Divide,
+    FloorDivide,
+    GreaterEqual,
+    GreaterThan,
+    LessEqual,
+    LessThan,
+    Minus,
+    Modulo,
+    Multiply,
+    Or,
+    Plus,
+    Power,
 )
 from stylo.testing.math import BaseBinaryOpTest
 
 
 @pytest.mark.math
-class TestStyAnd(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyAnd` binary operation."""
+class TestAnd(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`And` binary operation."""
 
     def setUp(self):
-        self.operation = StyAnd
+        self.operation = And
         self.examples = [
             (False, False, False),
             (False, True, False),
@@ -45,11 +45,11 @@ class TestStyAnd(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyDivide(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyDivide` binary operation."""
+class TestDivide(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Divide` binary operation."""
 
     def setUp(self):
-        self.operation = StyDivide
+        self.operation = Divide
         self.examples = [
             (12, 1, 12),
             (3, 2, 1.5),
@@ -59,11 +59,11 @@ class TestStyDivide(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyFloorDivide(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyFloorDivide` binary operation."""
+class TestFloorDivide(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`FloorDivide` binary operation."""
 
     def setUp(self):
-        self.operation = StyFloorDivide
+        self.operation = FloorDivide
         self.examples = [
             (12, 1, 12),
             (3, 2, 1),
@@ -73,11 +73,11 @@ class TestStyFloorDivide(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyGreaterEqual(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyGreaterEqual` binary operation."""
+class TestGreaterEqual(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`GreaterEqual` binary operation."""
 
     def setUp(self):
-        self.operation = StyGreaterEqual
+        self.operation = GreaterEqual
         self.examples = [
             (1, 2, False),
             (2, 2, True),
@@ -87,11 +87,11 @@ class TestStyGreaterEqual(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyGreaterThan(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyGreaterThan` binary operation."""
+class TestGreaterThan(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`GreaterThan` binary operation."""
 
     def setUp(self):
-        self.operation = StyGreaterThan
+        self.operation = GreaterThan
         self.examples = [
             (1, 2, False),
             (2, 2, False),
@@ -101,11 +101,11 @@ class TestStyGreaterThan(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyLessEqual(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyLessEqual` binary operator."""
+class TestLessEqual(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`LessEqual` binary operator."""
 
     def setUp(self):
-        self.operation = StyLessEqual
+        self.operation = LessEqual
         self.examples = [
             (1, 2, True),
             (2, 2, True),
@@ -115,11 +115,11 @@ class TestStyLessEqual(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyLessThan(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyLessThan` binary operator."""
+class TestLessThan(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`LessThan` binary operator."""
 
     def setUp(self):
-        self.operation = StyLessThan
+        self.operation = LessThan
         self.examples = [
             (1, 2, True),
             (2, 2, False),
@@ -129,11 +129,11 @@ class TestStyLessThan(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyMinus(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyMinus` binary operation."""
+class TestMinus(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Minus` binary operation."""
 
     def setUp(self):
-        self.operation = StyMinus
+        self.operation = Minus
         self.examples = [
             (1, 0, 1),
             (0, 1, -1),
@@ -143,11 +143,11 @@ class TestStyMinus(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyModulo(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyModulo` binary operation."""
+class TestModulo(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Modulo` binary operation."""
 
     def setUp(self):
-        self.operation = StyModulo
+        self.operation = Modulo
         self.examples = [
             (12, 1, 0),
             (12, 5, 2),
@@ -157,11 +157,11 @@ class TestStyModulo(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyMultiply(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyMultiply` binary operation."""
+class TestMultiply(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Multiply` binary operation."""
 
     def setUp(self):
-        self.operation = StyMultiply
+        self.operation = Multiply
         self.examples = [
             (2, 1, 2),
             (12, 0, 0),
@@ -171,11 +171,11 @@ class TestStyMultiply(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyOr(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyOr` binary operation."""
+class TestOr(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Or` binary operation."""
 
     def setUp(self):
-        self.operation = StyOr
+        self.operation = Or
         self.examples = [
             (False, False, False),
             (False, True, True),
@@ -190,11 +190,11 @@ class TestStyOr(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyPlus(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyPlus` binary operation."""
+class TestPlus(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Plus` binary operation."""
 
     def setUp(self):
-        self.operation = StyPlus
+        self.operation = Plus
         self.examples = [
             (0, 1, 1),
             (2, 3, 5),
@@ -204,11 +204,11 @@ class TestStyPlus(TestCase, BaseBinaryOpTest):
 
 
 @pytest.mark.math
-class TestStyPower(TestCase, BaseBinaryOpTest):
-    """Tests for the :code:`StyPower` binary operation."""
+class TestPower(TestCase, BaseBinaryOpTest):
+    """Tests for the :code:`Power` binary operation."""
 
     def setUp(self):
-        self.operation = StyPower
+        self.operation = Power
         self.examples = [
             (1, 2, 1),
             (2, 3, 8),


### PR DESCRIPTION
- Drop the `Sty` prefix on everything
- Rename `Expr` to `Expression`